### PR TITLE
Fix linking typo for Galaxy link

### DIFF
--- a/manuals/views/step9.md
+++ b/manuals/views/step9.md
@@ -22,7 +22,7 @@ You can safely start with those solutions knowing that you won't have to switch 
 
 Next steps:
 
-* If you'd like to deploy this app to a production server, we recommend you check out Meteor Galaxy, the cloud service for [https://www.meteor.com/hosting](hosting and managing Meteor apps).
+* If you'd like to deploy this app to a production server, we recommend you check out Meteor Galaxy, the cloud service for [hosting and managing Metoer apps](https://www.meteor.com/hosting).
 * Check out [https://www.meteor.com/](https://www.meteor.com/) for many more resources
 * Go to [http://angular-meteor.com/](http://angular-meteor.com/) and check out the [advanced tutorial](http://angular-meteor.com/tutorials/angular1/bootstrapping)
 [}]: #


### PR DESCRIPTION
Fixed typo that is causing incorrect linking on step 10 of the tutorial:

https://angular-meteor.com/tutorials/whatsapp/meteor/summary

The broken link is the first list item under "next steps" on the above page.