### PR TITLE
Fix links in next steps

### DIFF
--- a/manuals/templates/step9.md
+++ b/manuals/templates/step9.md
@@ -18,6 +18,6 @@ You can safely start with those solutions knowing that you won't have to switch 
 
 Next steps:
 
-* If you'd like to deploy this app to a production server, we recommend you check out Meteor Galaxy, the cloud service for [https://www.meteor.com/hosting](hosting and managing Meteor apps).
+* If you'd like to deploy this app to a production server, we recommend you check out Meteor Galaxy, the cloud service for [hosting and managing Meteor apps](https://www.meteor.com/hosting).
 * Check out [https://www.meteor.com/](https://www.meteor.com/) for many more resources
-* Go to [http://angular-meteor.com/](http://angular-meteor.com/) and check out the [advanced tutorial](http://angular-meteor.com/tutorials/angular1/bootstrapping)
+* Go to [http://angular-meteor.com/](http://angular-meteor.com/) and check out the [advanced tutorial](https://angular-meteor.com/tutorials/whatsapp2-tutorial)


### PR DESCRIPTION
- Fix markdown on Meteor Hosting link (href & anchor text were wrong way round)
- Updated dead 404-ing link to advanced tutorial with existing followup lesson