### PR TITLE
correct link

### DIFF
--- a/manuals/templates/step9.md
+++ b/manuals/templates/step9.md
@@ -18,6 +18,6 @@ You can safely start with those solutions knowing that you won't have to switch 
 
 Next steps:
 
-* If you'd like to deploy this app to a production server, we recommend you check out Meteor Galaxy, the cloud service for [https://www.meteor.com/hosting](hosting and managing Meteor apps).
+* If you'd like to deploy this app to a production server, we recommend you check out Meteor Galaxy, the cloud service for [hosting and managing Meteor apps](https://www.meteor.com/hosting).
 * Check out [https://www.meteor.com/](https://www.meteor.com/) for many more resources
 * Go to [http://angular-meteor.com/](http://angular-meteor.com/) and check out the [advanced tutorial](http://angular-meteor.com/tutorials/angular1/bootstrapping)


### PR DESCRIPTION
Earlier, the URL was pointing to the text. On clicking the url, it attempted to  load the text at domain resulting in a 404.

On examining, the href text and the link were exchanged. As in the expected behaviour would've been to click the text and go to the link. The PR corrects the substitution.

Now, when the user clicks on the text, they get redirected to the link as I presume was the earlier intended action.